### PR TITLE
Rely on close() to close sockets and stop using shutdown()

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -301,10 +301,9 @@ class KMIPProxy(object):
         self.close()
 
     def close(self):
-        # Shutdown and close the socket.
+        # Close the socket.
         if self.socket:
             try:
-                self.socket.shutdown(socket.SHUT_RDWR)
                 self.socket.close()
             except (OSError, socket.error):
                 # Can be thrown if the socket is not actually connected to

--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -362,12 +362,11 @@ class KmipServer(object):
 
         self._logger.info("Shutting down server socket handler.")
         try:
-            self._socket.shutdown(socket.SHUT_RDWR)
             self._socket.close()
         except Exception as e:
             self._logger.exception(e)
             raise exceptions.NetworkingError(
-                "Server failed to shutdown socket handler."
+                "Server failed to close socket handler."
             )
 
         if hasattr(self, "policy_monitor"):

--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -113,7 +113,6 @@ class KmipSession(threading.Thread):
                     self._logger.info("Failure handling message loop")
                     self._logger.exception(e)
 
-        self._connection.shutdown(socket.SHUT_RDWR)
         self._connection.close()
         self._logger.info("Stopping session: {0}".format(self.name))
 


### PR DESCRIPTION
Fixes the noisy logging errors described in https://github.com/OpenKMIP/PyKMIP/pull/682
